### PR TITLE
chore: Add opencv package in requirements.txt

### DIFF
--- a/main.ipynb
+++ b/main.ipynb
@@ -18,7 +18,8 @@
     "import matplotlib.pyplot as plt\n",
     "from tensorflow.keras.applications import MobileNetV2\n",
     "import tensorflow as tf\n",
-    "from tensorflow import keras"
+    "from tensorflow import keras\n",
+    "import cv2"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ ml-dtypes==0.3.2
 namex==0.0.7
 nest-asyncio==1.6.0
 numpy==1.26.4
+opencv-python==4.9.0.80
 opt-einsum==3.3.0
 optree==0.10.0
 packaging==24.0


### PR DESCRIPTION
The Opencv package has been included in our project. 

You can run the following command to install it:
```
pip install -r requirements.txt
```
This command can keep all your Python packages up to date in your local virtual environment as well.